### PR TITLE
build.py: add -g option to use git as well as environment variables

### DIFF
--- a/build.py
+++ b/build.py
@@ -113,6 +113,7 @@ api = None
 token = None
 job = None
 boot_cmd = None
+use_git = False
 use_environment = False
 
 # temp frag file: used to collect all kconfig fragments
@@ -125,7 +126,7 @@ else:
     os.environ['ARCH'] = arch
 
 try:
-    opts, args = getopt.getopt(sys.argv[1:], "b:c:ip:se")
+    opts, args = getopt.getopt(sys.argv[1:], "b:c:ip:sge")
 
 except getopt.GetoptError as err:
     print str(err) # will print something like "option -a not recognized"
@@ -171,6 +172,9 @@ for o, a in opts:
             print "ERROR: unable to load configuration file"
     if o == '-s':
         silent = not silent
+    if o == '-g':
+        print("Getting build info from git")
+        use_git = True
     if o == '-e':
         print "Reading build variables from environment"
         publish = True
@@ -222,33 +226,22 @@ if ccache and len(ccache):
 else:
     ccache_dir = None
 
-# Gather info from environment variables
+if os.path.exists('.git') and use_git:
+    git_commit = subprocess.check_output('git log -n1 --format=%H', shell=True).strip()
+    git_url = subprocess.check_output('git config --get remote.origin.url |cat', shell=True).strip()
+    git_branch = subprocess.check_output('git rev-parse --abbrev-ref HEAD', shell=True).strip()
+    git_describe = subprocess.check_output('git describe', shell=True).strip()
+    git_describe_v = subprocess.check_output('git describe --match=v[234]\*', shell=True).strip()
+
+# Override info using environment variables
 if use_environment:
     api = os.environ.get('API', api)
     token = os.environ.get('TOKEN', token)
-    if os.environ.has_key('GIT_DESCRIBE'):
-        git_describe = os.environ['GIT_DESCRIBE']
-    if os.environ.has_key('GIT_DESCRIBE_VERBOSE'):
-        git_describe_v = os.environ['GIT_DESCRIBE_VERBOSE']
-    if os.environ.has_key('BRANCH'):
-        git_branch = os.environ['BRANCH']
-    if os.environ.has_key('COMMIT_ID'):
-        git_commit = os.environ['COMMIT_ID']
-    if os.environ.has_key('TREE'):
-        git_url = os.environ['TREE']
-else:
-    # Gather info from .git
-    if os.path.exists('.git'):
-        git_commit = subprocess.check_output('git log -n1 --format=%H', shell=True).strip()
-        git_url = subprocess.check_output('git config --get remote.origin.url |cat', shell=True).strip()
-        git_branch = subprocess.check_output('git rev-parse --abbrev-ref HEAD', shell=True).strip()
-        git_describe_v = subprocess.check_output('git describe --match=v[234]\*', shell=True).strip()
-        git_describe = subprocess.check_output('git describe', shell=True).strip()
-    else:
-        print "Could not gather build information from environment or .git directory"
-        exit(1)
-
-
+    git_commit = os.environ.get('COMMIT_ID', git_commit)
+    git_url = os.environ.get('TREE', git_url)
+    git_branch = os.environ.get('BRANCH', git_branch)
+    git_describe = os.environ.get('GIT_DESCRIBE', git_describe)
+    git_describe_v = os.environ.get('GIT_DESCRIBE_VERBOSE', git_describe_v)
 
 cc_cmd = "gcc -v 2>&1"
 if cross_compile:

--- a/build.py
+++ b/build.py
@@ -173,8 +173,6 @@ for o, a in opts:
         silent = not silent
     if o == '-e':
         print "Reading build variables from environment"
-        api = os.environ['API']
-        token = os.environ['TOKEN']
         publish = True
         use_environment = True
 
@@ -226,6 +224,8 @@ else:
 
 # Gather info from environment variables
 if use_environment:
+    api = os.environ.get('API', api)
+    token = os.environ.get('TOKEN', token)
     if os.environ.has_key('GIT_DESCRIBE'):
         git_describe = os.environ['GIT_DESCRIBE']
     if os.environ.has_key('GIT_DESCRIBE_VERBOSE'):


### PR DESCRIPTION
Enable a combination of git commands and environment variables to
gather the global build info:

* add the -g option to enable calling git if a .git directory is
  present and get the build info this way

* make the -e option look in the environment for values to override
  what was found by git if -g was also enabled

This is necessary in particular when running a git bisection to
explicitly provide the git branch when calling the script while the
repository is in a detached HEAD, while still running "git describe"
and "git url" to get the other pieces of information.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>
Fixes: 4b83734b1b4f2f35ae36e5426143e570ab838259