### PR TITLE
build.py: default use_git = True

### DIFF
--- a/build.py
+++ b/build.py
@@ -142,7 +142,7 @@ api = None
 token = None
 job = None
 boot_cmd = None
-use_git = False
+use_git = True
 use_environment = False
 
 # temp frag file: used to collect all kconfig fragments


### PR DESCRIPTION
Before this option was added, the default was to always use git, so make
that the default.

Signed-off-by: Kevin Hilman <khilman@baylibre.com>