### PR TITLE
jenkins: add x86 defconfig build

### DIFF
--- a/jenkins/kernel-defconfig-creator.sh
+++ b/jenkins/kernel-defconfig-creator.sh
@@ -80,6 +80,7 @@ if [ ${ARCH} = "arm64" ]; then
 fi
 
 if [ ${ARCH} = "x86" ]; then
+  DEFCONFIG_LIST+="$base_defconfig "
   DEFCONFIG_LIST+="allmodconfig "
 
   # Fragments


### PR DESCRIPTION
x86 builds are missing the build for the default 'defconfig' because no file
of that name exists in arch/x86/configs/*.  Add it manually so the default
is always built.

Signed-off-by: Kevin Hilman <khilman@baylibre.com>