### PR TITLE
Images

### DIFF
--- a/jenkins/debian/Jenkinsfile
+++ b/jenkins/debian/Jenkinsfile
@@ -4,7 +4,7 @@ library identifier: 'kernelci-build-staging@master', retriever: modernSCM(
 
 buildImage {
 
-    name = 'basic'
+    name = 'squeeze'
     archList = ["armhf", "armel", "arm64", "x86", "x86_64"]
 
     //Extra packages to be installed in the image

--- a/jenkins/debian/Jenkinsfile_squeezetests
+++ b/jenkins/debian/Jenkinsfile_squeezetests
@@ -1,0 +1,16 @@
+library identifier: 'kernelci-build-staging@master', retriever: modernSCM(
+  [$class: 'GitSCMSource',
+   remote: 'http://github.com/kernelci/kernelci-build-staging'])
+
+buildImage {
+
+    name = 'squeezetests'
+    archList = ["armhf", "armel", "arm64", "x86", "x86_64"]
+
+
+    //Extra packages to be installed in the image
+    extra_packages = "libpciaccess0 libkmod2 libprocps6 libcairo2 libunwind8 libudev1 libglib2.0-0"
+
+    // script to build the testsuite(s)
+    script = "scripts/squeezetests.sh"
+}

--- a/jenkins/debian/debos/scripts/squeezetests.sh
+++ b/jenkins/debian/debos/scripts/squeezetests.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+
+# Important: This script is run under QEMU
+
+set -e
+
+# Build-depends needed to build the test suites, they'll be removed later
+BUILD_DEPS="libpciaccess-dev \
+    libkmod-dev \
+    libprocps-dev \
+    libcairo2-dev \
+    libunwind-dev  \
+    libudev-dev  \
+    git \
+    autoconf \
+    xutils-dev \
+    autogen \
+    libtool \
+    automake \
+    python \
+    python-requests \
+    cpio \
+    gettext \
+    build-essential \
+    dpkg-dev \
+"
+
+apt-get install --no-install-recommends -y  ${BUILD_DEPS}
+
+########################################################################
+# Build tests                                                          #
+########################################################################
+
+
+# Build libdrm
+########################################################################
+
+mkdir -p /tmp/tests/libdrm && cd /tmp/tests/libdrm
+git clone --depth=1 git://anongit.freedesktop.org/mesa/drm .
+
+autoreconf --force --verbose --install
+./configure --enable-intel --prefix=/tmp/tests/igt/usr/
+make -j$(nproc) V=1
+make -j$(nproc) install V=1
+
+# copy libdrm libraries in the image
+cp -a /tmp/tests/igt/usr/lib/lib*.so* /usr/lib/
+
+# Build IGT
+########################################################################
+
+mkdir -p /tmp/tests/igt-gpu-tools && cd /tmp/tests/igt-gpu-tools
+git clone --depth=1 git://anongit.freedesktop.org/drm/igt-gpu-tools .
+
+PKG_CONFIG_PATH=/tmp/tests/igt/usr/lib/pkgconfig sh autogen.sh
+make V=1
+mkdir -p /tmp/tests/igt2/usr/bin
+cp -a tests/core_auth tests/core_get_client_auth tests/core_getclient tests/core_getstats tests/core_getversion \
+    tests/core_prop_blob tests/core_setmaster_vs_auth tests/drm_read tests/kms_addfb_basic tests/kms_atomic \
+    tests/kms_flip_event_leak tests/kms_setmode tests/kms_vblank tests/kms_frontbuffer_tracking tests/kms_flip  /tmp/tests/igt2/usr/bin
+strip /tmp/tests/igt2/usr/bin/*
+
+# Copy binaries in the image
+cp -a /tmp/tests/igt2/usr/bin/* /usr/bin/
+
+
+# Build v4l2
+########################################################################
+
+mkdir -p /tmp/tests/v4l2-compliance && cd /tmp/tests/v4l2-compliance
+
+git clone --depth=1 git://linuxtv.org/v4l-utils.git .
+
+sh bootstrap.sh
+./configure --prefix=/tmp/tests/v4l2/usr/ --with-udevdir=/tmp/tests/v4l2/usr/lib/udev
+make V=1
+make V=1 install
+strip /tmp/tests/v4l2/usr/bin/* /tmp/tests/v4l2/usr/lib/*.so* /tmp/tests/v4l2/usr/lib/libv4l/*.so*
+
+# Copy files in the image
+rm -rf  /tmp/tests/v4l2/usr/include /tmp/tests/v4l2/usr/share /tmp/tests/v4l2/usr/lib/udev /tmp/tests/v4l2/usr/lib/pkgconfig/
+cp -a /tmp/tests/v4l2/usr/* /usr/
+
+
+########################################################################
+# Cleanup: remove files and packages we don't want in the images       #
+########################################################################
+cd /tmp
+rm -rf /tmp/tests
+
+apt-get remove --purge -y ${BUILD_DEPS}
+apt-get remove --purge -y perl-modules-5.24
+apt-get autoremove --purge -y
+apt-get clean
+
+# re-add some stuff that is removed by accident
+apt-get install -y initramfs-tools
+

--- a/jenkins/debian/debos/stretch.yaml
+++ b/jenkins/debian/debos/stretch.yaml
@@ -89,7 +89,7 @@ actions:
 
   - action: image-partition
     imagename: rootfs.ext4
-    imagesize: 500MB
+    imagesize: 1GB
     partitiontype: msdos
     mountpoints:
       - mountpoint: /

--- a/jenkins/debian/debos/stretch.yaml
+++ b/jenkins/debian/debos/stretch.yaml
@@ -2,6 +2,7 @@
 {{- $basename := or .basename "." -}}
 {{- $extra_packages := or .extra_packages "" -}}
 {{- $suite := or .suite "stretch" -}}
+{{- $script := or .script "scripts/nothing.sh" -}}
 
 architecture: {{ $architecture }}
 
@@ -24,6 +25,11 @@ actions:
       - usbutils
       - initramfs-tools
       - patch
+
+  - action: run
+    description: Build testsuite
+    chroot: true
+    script: {{ $script }}
 
   - action: run
     description: Install extra packages

--- a/vars/buildImage.groovy
+++ b/vars/buildImage.groovy
@@ -1,3 +1,24 @@
+/*
+  Copyright (C) 2018 Collabora Limited
+  Author: Ana Guerrero Lopez <ana.guerrero@collabora.com>
+
+  This module is free software; you can redistribute it and/or modify it under
+  the terms of the GNU Lesser General Public License as published by the Free
+  Software Foundation; either version 2.1 of the License, or (at your option)
+  any later version.
+
+  This library is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+  FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+  details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with this library; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+
+
 /* TODO:
 - Harcoded paths at jenkins/debian/... for Dockerfile and debos file
 */

--- a/vars/buildImage.groovy
+++ b/vars/buildImage.groovy
@@ -35,14 +35,15 @@ def call(Closure context) {
                                                     arch,
                                                     debian_arch[arch],
                                                     debosFile,
-                                                    extraPackages)
+                                                    extraPackages,
+                                                    name)
     }
 
     parallel stepsForParallel
 }
 
 
-def makeImageStep(String pipeline_version, String arch, String debian_arch, String debosFile, String extraPackages) {
+def makeImageStep(String pipeline_version, String arch, String debian_arch, String debosFile, String extraPackages, String name) {
     return {
         node('builder' && 'docker') {
             stage("Checkout") {
@@ -66,7 +67,7 @@ def makeImageStep(String pipeline_version, String arch, String debian_arch, Stri
                     withCredentials([string(credentialsId: 'Staging KernelCI API Token', variable: 'API_TOKEN')]) {
                         sh """
                             python push-source.py --token ${API_TOKEN} --api https://staging-api.kernelci.org \
-                                --publish_path images/rootfs/debian/stretch/${arch} \
+                                --publish_path images/rootfs/debian/${name}/ \
                                 --file ${pipeline_version}/${arch}/*.*
                         """
                     }


### PR DESCRIPTION
This pull request adds a new Jenkins pipeline to build images with  the test suites included. It also uses the library provided under ` vars/buildImage`. This library together with the debos files have been  modified to allow building the test suites through a shell script  specified in the  Jenkinsfile (`debos/scripts/squeezetests.sh` in this case).

`debos/scripts/squeezetests.sh` installs all the build-depends required  to build the test suites, build each test suite, copies the files in the  final image and removes all the packages installed in the first step.
The runtime dependencies that must be installed in the images are listed in the field  extra_packages in the Jenkinsfile.

The first two commits are for updating the upload path of the images  to `images/rootfs/debian/$NAME/YYYYMMDD.N/$ARCH/`. For this, I have changed the name of the current pipeline (Jenkinsfile) to squeeze so the base images will be upload to `images/rootfs/debian/squeeze/ ...` and the images of the new pipeline, named squeezetests will be under` images/rootfs/squeezetests/...`






