### PR TITLE
jenkins: defconfig-creator: check/build debug fragments

### DIFF
--- a/jenkins/kernel-defconfig-creator.sh
+++ b/jenkins/kernel-defconfig-creator.sh
@@ -91,6 +91,12 @@ if [ ${ARCH} = "x86" ]; then
   done
 fi
 
+# debug builds
+DEBUG_FRAG=kernel/configs/debug.config
+if [ -e $DEBUG_FRAG ]; then
+  DEFCONFIG_LIST+="$base_defconfig+$DEBUG_FRAG "
+fi
+
 # kselftests
 KSELFTEST_FRAG=kernel/configs/kselftest.config
 if [ -e $KSELFTEST_FRAG ]; then


### PR DESCRIPTION
Check for kconfig fragment kernel/configs/debug.config and add it to the
list of defconfigs to build if present.

Currently, upstream trees do not yet have this fragment, but it has been
discussed a few times.  So, currently it will not add additional builds
for upstream trees.

Signed-off-by: Kevin Hilman <khilman@baylibre.com>