### PR TITLE
debian/Jenkinsfiles: use shared libraries declared in Jenkins

### DIFF
--- a/jenkins/debian/Jenkinsfile
+++ b/jenkins/debian/Jenkinsfile
@@ -1,6 +1,4 @@
-library identifier: 'kernelci-build-staging@master', retriever: modernSCM(
-  [$class: 'GitSCMSource',
-   remote: 'http://github.com/kernelci/kernelci-build-staging'])
+@Library('kernelci') _
 
 buildImage {
 

--- a/jenkins/debian/Jenkinsfile_stretchtests
+++ b/jenkins/debian/Jenkinsfile_stretchtests
@@ -1,6 +1,4 @@
-library identifier: 'kernelci-build-staging@master', retriever: modernSCM(
-  [$class: 'GitSCMSource',
-   remote: 'http://github.com/kernelci/kernelci-build-staging'])
+@Library('kernelci') _
 
 buildImage {
 


### PR DESCRIPTION
The shared libraries are now declared directly in the global jenkins configuration in staging.