### PR TITLE
debos/overlays/networkd: do not re-initialise network when using NFS root

### DIFF
--- a/jenkins/debian/debos/overlays/networkd/etc/systemd/network/wired.network
+++ b/jenkins/debian/debos/overlays/networkd/etc/systemd/network/wired.network
@@ -1,5 +1,6 @@
 [Match]
 Name=e*
+KernelCommandLine=!nfsroot
 
 [Network]
 DHCP=yes


### PR DESCRIPTION
See https://groups.io/g/kernelci/message/16