### PR TITLE
RFC: vars/buildImage: staging -> production

### DIFF
--- a/vars/buildImage.groovy
+++ b/vars/buildImage.groovy
@@ -92,9 +92,9 @@ def makeImageStep(String pipeline_version, String arch, String debian_arch, Stri
                 }
 
                 stage("Upload images for ${arch}") {
-                    withCredentials([string(credentialsId: 'Staging KernelCI API Token', variable: 'API_TOKEN')]) {
+                    withCredentials([string(credentialsId: 'KernelCI Upload API Token', variable: 'API_TOKEN')]) {
                         sh """
-                            python push-source.py --token ${API_TOKEN} --api https://staging-api.kernelci.org \
+                            python push-source.py --token ${API_TOKEN} --api https://api.kernelci.org \
                                 --publish_path images/rootfs/debian/${name}/ \
                                 --file ${pipeline_version}/${arch}/*.*
                         """


### PR DESCRIPTION
@gctucker You've already done some work in unifying tokens between staging and master.  Is there  a better way to do this so we have a job that works on both staging and production?