### PR TITLE
Use job parameters and add then automatically in the job configuration

### DIFF
--- a/vars/buildImage.groovy
+++ b/vars/buildImage.groovy
@@ -17,6 +17,15 @@
   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 */
 
+/* ----------------------------------------------------------------------------
+ * Jenkins parameters
+
+KCI_API_URL (https://api.kernelci.org)
+  URL of the KernelCI backend API
+KCI_TOKEN_ID
+  Identifier of the KernelCI backend API token stored in Jenkins
+
+*/
 
 
 /* TODO:
@@ -92,9 +101,9 @@ def makeImageStep(String pipeline_version, String arch, String debian_arch, Stri
                 }
 
                 stage("Upload images for ${arch}") {
-                    withCredentials([string(credentialsId: 'Staging KernelCI API Token', variable: 'API_TOKEN')]) {
+                    withCredentials([string(credentialsId: params.KCI_TOKEN_ID, variable: 'API_TOKEN')]) {
                         sh """
-                            python push-source.py --token ${API_TOKEN} --api https://staging-api.kernelci.org \
+                            python push-source.py --token ${API_TOKEN} --api ${params.KCI_API_URL} \
                                 --publish_path images/rootfs/debian/${name}/ \
                                 --file ${pipeline_version}/${arch}/*.*
                         """


### PR DESCRIPTION
This PR is addressing the discussion at https://github.com/kernelci/kernelci-build-staging/pull/35

There are two commits:
* The first one merely uses parameters instead of hard-coding values as agreed in the link above.
* The second commit will create the parameters automatically in the jenkins UI (in the part job configuration screen). This is done during the first run of the job when it'll also clear all the existing parameters of the job. 
IMPORTANT: This means the job will have to be always run a second time after its setup to have the "Build with parameters" menu available and that any parameter defined for its first run will be removed or updated. This should make handling the parameters for every job easier!
