### PR TITLE
debian/debos/scripts/stretchtests.sh Add kms_cursor_legacy to the image

### DIFF
--- a/jenkins/debian/debos/scripts/stretchtests.sh
+++ b/jenkins/debian/debos/scripts/stretchtests.sh
@@ -57,7 +57,8 @@ make V=1
 mkdir -p /tmp/tests/igt2/usr/bin
 cp -a tests/core_auth tests/core_get_client_auth tests/core_getclient tests/core_getstats tests/core_getversion \
     tests/core_prop_blob tests/core_setmaster_vs_auth tests/drm_read tests/kms_addfb_basic tests/kms_atomic \
-    tests/kms_flip_event_leak tests/kms_setmode tests/kms_vblank tests/kms_frontbuffer_tracking tests/kms_flip  /tmp/tests/igt2/usr/bin
+    tests/kms_flip_event_leak tests/kms_setmode tests/kms_vblank tests/kms_frontbuffer_tracking tests/kms_flip  \
+    tests/kms_cursor_legacy /tmp/tests/igt2/usr/bin
 strip /tmp/tests/igt2/usr/bin/*
 
 # Copy binaries in the image

--- a/jenkins/debian/debos/scripts/stretchtests.sh
+++ b/jenkins/debian/debos/scripts/stretchtests.sh
@@ -58,7 +58,7 @@ mkdir -p /tmp/tests/igt2/usr/bin
 cp -a tests/core_auth tests/core_get_client_auth tests/core_getclient tests/core_getstats tests/core_getversion \
     tests/core_prop_blob tests/core_setmaster_vs_auth tests/drm_read tests/kms_addfb_basic tests/kms_atomic \
     tests/kms_flip_event_leak tests/kms_setmode tests/kms_vblank tests/kms_frontbuffer_tracking tests/kms_flip  \
-    tests/kms_cursor_legacy /tmp/tests/igt2/usr/bin
+    tests/kms_cursor_legacy tests/testdisplay /tmp/tests/igt2/usr/bin
 strip /tmp/tests/igt2/usr/bin/*
 
 # Copy binaries in the image


### PR DESCRIPTION
kms_cursor_legacy is also helpful when running the IGT testsuite.

Signed-off-by: Ana Guerrero Lopez <ana.guerrero@collabora.com>