### PR TITLE
T9828 build.jpl: run the job on shared-builder nodes rathern than trigger

### DIFF
--- a/jenkins/build.jpl
+++ b/jenkins/build.jpl
@@ -181,7 +181,7 @@ def archComplete(job) {
     }
 }
 
-node("trigger") {
+node("shared-builder") {
     env.CONFIG_NUMBER = 0
     def configs = params.DEFCONFIG_LIST.tokenize(' ')
 


### PR DESCRIPTION
Leave the "trigger" node for trigger jobs, and run the build jobs on
the "shared-builder" nodes instead.

This means one executor on these nodes will be used to run the
top-level job while others will run individual kernel build stages.
The utilisation of the builders should not be impacted as long as
there are enough executors set up on them.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>