### PR TITLE
build pipeline: more descriptive task names

### DIFF
--- a/jenkins/build-trigger.jpl
+++ b/jenkins/build-trigger.jpl
@@ -229,10 +229,10 @@ node("defconfig-creator") {
     stage("Init") {
         timeout(time: 30, unit: 'MINUTES') {
             parallel(
-                p1: { k.cloneKCIBuild(kci_build,
+                clone: { k.cloneKCIBuild(kci_build,
                                       params.KCI_BUILD_URL,
                                       params.KCI_BUILD_BRANCH) },
-                p2: { k.downloadTarball(kdir, params.SRC_TARBALL) },
+                download: { k.downloadTarball(kdir, params.SRC_TARBALL) },
             )
         }
     }

--- a/jenkins/build.jpl
+++ b/jenkins/build.jpl
@@ -99,10 +99,10 @@ node("shared-builder") {
     stage("Init") {
         timeout(time: 30, unit: 'MINUTES') {
             parallel(
-                p1: { k.cloneKCIBuild(kci_build,
+                clone: { k.cloneKCIBuild(kci_build,
                                       params.KCI_BUILD_URL,
                                       params.KCI_BUILD_BRANCH) },
-                p2: { k.downloadTarball(kdir, params.SRC_TARBALL) },
+                download: { k.downloadTarball(kdir, params.SRC_TARBALL) },
             )
         }
     }


### PR DESCRIPTION
Rename the parallel task names to more descriptive values, so the
jenkins console output is more readable by humans who haven't read the
groovy code.

Signed-off-by: Kevin Hilman <khilman@baylibre.com>