### PR TITLE
T7303 FIXUP build.jpl: fix kernelci lib import name

### DIFF
--- a/jenkins/build.jpl
+++ b/jenkins/build.jpl
@@ -56,7 +56,7 @@ KCI_BUILD_BRANCH (master)
  */
 
 
-@Library('kernelci-gtucker') _
+@Library('kernelci') _
 import org.kernelci.build.Kernel
 import org.kernelci.util.Job
 


### PR DESCRIPTION
The kernelci-gtucker library name was only temporary to test the new
job on staging.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>
Fixes: 75c4b6bfc31b ("build.jpl: only build one defconfig and do not schedule build report")