### PR TITLE
RFC build.jpl: enable multiple builds on same builder using lock labels

### DIFF
--- a/jenkins/build.jpl
+++ b/jenkins/build.jpl
@@ -108,7 +108,7 @@ node("shared-builder") {
     }
 
     stage("Build") {
-        lock("${env.NODE_NAME}-build-lock") {
+        lock(label: "${env.NODE_NAME}-build-lock", quantity: 1) {
             timeout(time: 60, unit: 'MINUTES') {
                 buildConfig(params.DEFCONFIG, kdir, kci_build)
             }


### PR DESCRIPTION
Some builders have a lot of CPU power, and running only one kernel
build at a time on them results in a rather low utilisation of their
available build power.  We currently have one build lock per builder,
allowing other stages to run in preparation for the next build
(checking out code, waiting for a LAVA job in the case of
bisection...).  In order to run several builds, we need several
lockable resources per builder.

The Lockable Resources plugins in Jenkins provides a way to define a
pool of resources using labels.  We can define several lockable
resources for a given builder by giving all of them a label with the
name of the builder.  Then build jobs can require to lock one of them,
allowing more than one build to run at the same time if there are
several locks with the same label.  This is what this patch does.

The downside is that the plugin can automatically create new lockable
resources that don't exist, but not with labels.  So when a new
builder is added in Jenkins, a lockable resource can be automatically
created when the first job runs on it.  When using labels, this can't
be done, so all the locks need to be set up manually with their labels
when adding new builders, even for builders with only one lock.

So we need to determine whether the added build throughput it is worth
the extra maintenance.  I guess it mainly depends on the number of
available builders with a large number of CPUs.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>