### PR TITLE
build.py: add build threads to metadata

### DIFF
--- a/build.py
+++ b/build.py
@@ -448,6 +448,7 @@ if install:
         shutil.copy(os.path.join(tmp_mod_dir, modules_tarball), install_path)
         shutil.rmtree(tmp_mod_dir)
 
+    bmeta["build_threads"] = make_threads
     bmeta["build_time"] = round(build_time, 2)
     if result == 0:
         bmeta['build_result'] = "PASS"


### PR DESCRIPTION
For future build-time optimization, track the number of build threads
(make -j level) for every build.

New build.json field: build_threads

Along with build time, this data can be used to optimize build
throughput across the various build servers.

Signed-off-by: Kevin Hilman <khilman@baylibre.com>