### PR TITLE
T10166 no build lock

### DIFF
--- a/build.py
+++ b/build.py
@@ -67,7 +67,7 @@ git_commit = None
 git_url = None
 git_branch = None
 ccache = None
-make_threads = 2
+make_threads = None
 kbuild_output_prefix = 'build'
 silent = True
 build_target = None
@@ -150,6 +150,9 @@ use_environment = False
 # temp frag file: used to collect all kconfig fragments
 kconfig_tmpfile_fd, kconfig_tmpfile = tempfile.mkstemp(prefix='kconfig-')
 
+# Set number of make threads to number of local processors + 2
+make_threads = int(subprocess.check_output('nproc', shell=True)) + 2
+
 # ARCH
 if os.environ.has_key('ARCH'):
     arch = os.environ['ARCH']
@@ -157,7 +160,7 @@ else:
     os.environ['ARCH'] = arch
 
 try:
-    opts, args = getopt.getopt(sys.argv[1:], "b:c:ip:sgeJ:")
+    opts, args = getopt.getopt(sys.argv[1:], "b:c:ip:sgeJ:j:")
 
 except getopt.GetoptError as err:
     print str(err) # will print something like "option -a not recognized"
@@ -213,14 +216,12 @@ for o, a in opts:
     if o == '-J':
         print("Not posting build data but saving to local JSON instead")
         build_data_json = a
+    if o == '-j':
+        make_threads = int(a)
+        print("Parallel builds: {}".format(make_threads))
 
 # Default umask for file creation
 os.umask(022)
-
-# Set number of make threads to number of local processors + 2
-if os.path.exists('/proc/cpuinfo'):
-    output = subprocess.check_output('nproc', shell=True)
-    make_threads = int(output) + 2
 
 # CROSS_COMPILE
 if cross_compilers.has_key(arch):

--- a/build.py
+++ b/build.py
@@ -157,7 +157,7 @@ else:
     os.environ['ARCH'] = arch
 
 try:
-    opts, args = getopt.getopt(sys.argv[1:], "b:c:ip:sgej:")
+    opts, args = getopt.getopt(sys.argv[1:], "b:c:ip:sgeJ:")
 
 except getopt.GetoptError as err:
     print str(err) # will print something like "option -a not recognized"
@@ -210,7 +210,7 @@ for o, a in opts:
         print "Reading build variables from environment"
         publish = True
         use_environment = True
-    if o == '-j':
+    if o == '-J':
         print("Not posting build data but saving to local JSON instead")
         build_data_json = a
 

--- a/jenkins/build.jpl
+++ b/jenkins/build.jpl
@@ -52,6 +52,8 @@ KCI_BUILD_URL (https://github.com/kernelci/kernelci-build.git)
   URL of the kernelci-build repository
 KCI_BUILD_BRANCH (master)
   Name of the branch to use in the kernelci-build repository
+PARALLEL_BUILDS
+  Number of kernel builds to run in parallel
 
  */
 
@@ -63,13 +65,16 @@ import org.kernelci.util.Job
 def buildConfig(config, kdir, kci_build) {
     def defconfig = sh(script: "echo ${config} | sed 's/\\+/ \\-c /g'",
                        returnStdout: true)
-    def opt = ""
+    def opt = "-i"
 
     if (params.PUBLISH) {
-        opt = "-e"
+        opt += " -e"
     } else {
         echo "NOT PUBLISHING"
     }
+
+    if (params.PARALLEL_BUILDS)
+        opt += " -j${params.PARALLEL_BUILDS}"
 
     dir(kdir) {
         withCredentials([string(credentialsId: params.KCI_TOKEN_ID,
@@ -77,12 +82,15 @@ def buildConfig(config, kdir, kci_build) {
             sh(script: """
 API=${params.KCI_API_URL} \
 TOKEN=${SECRET} \
-${kci_build}/build.py -i ${opt} -c ${defconfig}""")
+${kci_build}/build.py \
+  ${opt} \
+  -c ${defconfig} \
+""")
         }
     }
 }
 
-node("shared-builder") {
+node("builder") {
     echo("""\
     Tree:      ${params.TREE_NAME}
     URL:       ${params.TREE}
@@ -108,10 +116,8 @@ node("shared-builder") {
     }
 
     stage("Build") {
-        lock("${env.NODE_NAME}-build-lock") {
-            timeout(time: 60, unit: 'MINUTES') {
-                buildConfig(params.DEFCONFIG, kdir, kci_build)
-            }
+        timeout(time: 180, unit: 'MINUTES') {
+            buildConfig(params.DEFCONFIG, kdir, kci_build)
         }
     }
 }


### PR DESCRIPTION
This is to reshape how regular builds are run:

* add `build.py -j` option to specify the number of parallel builds like in `make -j`
* add `PARALLEL_BUILDS` option to the `kernel-build` job to set this value
* do not hold the build lock any more, and extend build timeout to 3h
* run on `builder` nodes rather than `shared-builder`

The principle being that each `builder` node can have its number of executors set to `$(ncores)` / (-j value).  This is to maximise the available resources, especially on builders with over 16 CPU cores as `make -j` does not scale well above that.  A good value to start with would be `-j4`, so builders with 10 cores would have 3 executors, 16 cores 4 executors, 128 cores 32 executors etc...  Another limit is the available disk (or RAM) space as each `kernel-build` workspace instance takes about 1~2 GB.  Based on the results, we may tweak the value higher or lower to fine-tune it to our system.  It may also be possible to set this more dynamically depending on which node the build job lands on.

Bisections would run on separate `bisection` nodes and will continue to hold the lock as it makes sense for their use-case (i.e. waiting for LAVA jobs to complete before determining the next kernel revision to build...).