### PR TITLE
stretch test rootfs: add libssl to the build-deps and on runtine

### DIFF
--- a/jenkins/debian/Jenkinsfile_stretchtests
+++ b/jenkins/debian/Jenkinsfile_stretchtests
@@ -7,7 +7,7 @@ buildImage {
 
 
     //Extra packages to be installed in the image
-    extra_packages = "libpciaccess0 libkmod2 libprocps6 libcairo2 libunwind8 libudev1 libglib2.0-0"
+    extra_packages = "libpciaccess0 libkmod2 libprocps6 libcairo2 libssl1.1 libunwind8 libudev1 libglib2.0-0"
 
     // script to build the testsuite(s)
     script = "scripts/stretchtests.sh"

--- a/jenkins/debian/debos/scripts/stretchtests.sh
+++ b/jenkins/debian/debos/scripts/stretchtests.sh
@@ -11,6 +11,7 @@ BUILD_DEPS="libpciaccess-dev \
     libcairo2-dev \
     libunwind-dev  \
     libudev-dev  \
+    libssl-dev \
     git \
     autoconf \
     xutils-dev \


### PR DESCRIPTION
This is a new requirement for IGT GPU Tools.

This will fix building the testsuites rootfs that's broken in production.
